### PR TITLE
add feishu_cloud_doc skill — full Feishu/Lark cloud document integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ cp -r agentscope-skills/skills/{skill_name} ~/.cursor/skills/{skill_name}.md
 |------------------|---------------------------|------------------------------------------------------------------|
 | agentscope-skill | `skills/agentscope-skill` | Use this skill when building or working with AgentScope library. |
 | nano-memory      | `skills/nano-memory`      | Guidelines and workflows for the agent to maintain persistent memory using native file tools (read_file, write_file, edit_file) and standard OS commands for searching. |
-| feishu_cloud_doc | `skills/feishu_cloud_doc` | Operate on Feishu/Lark cloud documents via Open API. Covers Documents (Docx), Spreadsheets (Sheets), Bitables (multi-dimensional tables), Wiki (knowledge base), and sharing/permissions management. |
 | Coming soon...   | -                         | -                                                                |
 
 ---

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ cp -r agentscope-skills/skills/{skill_name} ~/.cursor/skills/{skill_name}.md
 |------------------|---------------------------|------------------------------------------------------------------|
 | agentscope-skill | `skills/agentscope-skill` | Use this skill when building or working with AgentScope library. |
 | nano-memory      | `skills/nano-memory`      | Guidelines and workflows for the agent to maintain persistent memory using native file tools (read_file, write_file, edit_file) and standard OS commands for searching. |
+| feishu_cloud_doc | `skills/feishu_cloud_doc` | Operate on Feishu/Lark cloud documents via Open API. Covers Documents (Docx), Spreadsheets (Sheets), Bitables (multi-dimensional tables), Wiki (knowledge base), and sharing/permissions management. |
 | Coming soon...   | -                         | -                                                                |
 
 ---

--- a/skills/feishu_cloud_doc/SKILL.md
+++ b/skills/feishu_cloud_doc/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: feishu_cloud_doc
+description: "当用户需要操作飞书/Lark 云文档时使用此 skill。涵盖四大模块：1) 在线文档（Docx）— 创建、读取、编辑飞书文档；2) 电子表格（Sheets）— 创建、读写飞书表格；3) 多维表格（Bitable）— 创建多维表格、管理字段和记录；4) 知识库（Wiki）— 管理知识空间和节点。触发关键词：飞书文档、飞书表格、飞书多维表格、飞书知识库、Feishu doc、Lark doc、云文档、在线文档、在线表格。不适用于本地 .docx/.xlsx 文件操作（那是 docx/xlsx skill 的职责）。"
+metadata:
+  builtin_skill_version: "1.0"
+  qwenpaw:
+    emoji: "📝"
+    requires:
+      envs: ["FEISHU_APP_ID", "FEISHU_APP_SECRET"]
+      bins: []
+---
+
+> **Important:** All `scripts/` paths are relative to this skill directory.
+> Every script requires `--workspace-dir {working_dir}` to locate `agent.json` with Feishu credentials.
+> Run with: `cd {this_skill_dir} && python scripts/xxx.py --workspace-dir {working_dir} ...`
+> The `{working_dir}` is your workspace directory (from env context "Working directory").
+
+# Feishu Cloud Document Skill
+
+Operate on Feishu/Lark cloud documents via the Open API. Covers **Documents**, **Spreadsheets**, **Bitables** (multi-dimensional tables), and **Wiki** (knowledge base).
+
+## Prerequisites
+
+- **httpx**: HTTP client (already included in QwenPaw dependencies)
+- **Feishu App credentials**: `FEISHU_APP_ID` and `FEISHU_APP_SECRET` (env vars or workspace `agent.json` → `channels.feishu`)
+- **App permissions** (enable in Feishu developer console):
+  - `docx:document` / `docx:document:readonly` — Documents
+  - `sheets:spreadsheet` / `sheets:spreadsheet:readonly` — Spreadsheets
+  - `bitable:app` / `bitable:app:readonly` — Bitables
+  - `wiki:wiki` / `wiki:wiki:readonly` — Wiki
+  - `drive:drive` — Cloud space access
+  - `drive:permission` — Permission management (sharing)
+
+## Authentication
+
+All scripts auto-obtain `tenant_access_token`. Credentials resolved in order:
+1. Env vars: `FEISHU_APP_ID`, `FEISHU_APP_SECRET`, `FEISHU_DOMAIN`
+2. Workspace `agent.json` → `channels.feishu` (via `--workspace-dir` argument)
+
+Set `FEISHU_DOMAIN=lark` for international (Lark) endpoints; default is `feishu` (China).
+
+## Default Permission Behavior
+
+Documents created by the app are initially **private** (only the app bot has access). After creating any document/spreadsheet/bitable, you should:
+
+- **If the user has no specific permission requirements**: Set org-wide link sharing to editable so the user can access it immediately:
+  ```bash
+  python scripts/share.py --workspace-dir {working_dir} --token TOKEN --type docx --public --link-access tenant_editable
+  ```
+- **If the user explicitly requests specific permissions** (e.g. "only share with me", "make it read-only", "share with xxx@example.com"): Follow the user's instructions using `share.py` accordingly.
+
+---
+
+## Module 1: Documents (Docx)
+
+### Quick Reference
+
+| Task | Command |
+|------|---------|
+| Create document | `python scripts/doc_create.py --workspace-dir {working_dir} --title "Title" [--folder TOKEN]` |
+| Read plain text | `python scripts/doc_read.py --workspace-dir {working_dir} --doc-id ID --format raw` |
+| Read block tree | `python scripts/doc_read.py --workspace-dir {working_dir} --doc-id ID --format blocks` |
+| Get doc metadata | `python scripts/doc_read.py --workspace-dir {working_dir} --doc-id ID --format info` |
+| Add content blocks | `python scripts/doc_edit.py --workspace-dir {working_dir} --doc-id ID --blocks-json '[...]'` |
+| Add from file | `python scripts/doc_edit.py --workspace-dir {working_dir} --doc-id ID --blocks-file path.json` |
+| Insert at position | `python scripts/doc_edit.py --workspace-dir {working_dir} --doc-id ID --blocks-json '[...]' --index 0` |
+| Delete block by ID | `python scripts/doc_edit.py --workspace-dir {working_dir} --doc-id ID --action delete --block-id BID` |
+| Delete by text (substring) | `python scripts/doc_edit.py --workspace-dir {working_dir} --doc-id ID --action delete-by-text --text "content"` |
+| Delete by text (exact) | `python scripts/doc_edit.py --workspace-dir {working_dir} --doc-id ID --action delete-by-text --text "content" --exact` |
+
+### Block Types
+
+| Type | Name | Content Key |
+|------|------|-------------|
+| 2 | Text | `text` |
+| 3–8 | Heading 1–6 | `heading1`–`heading6` |
+| 9 | Bullet list | `bullet` |
+| 10 | Ordered list | `ordered` |
+| 12 | Code block | `code` |
+| 14 | Divider | — |
+| 15 | Callout | `callout` |
+
+### Block Element Structure
+
+```json
+{"block_type": 3, "heading1": {"elements": [{"text_run": {"content": "Title", "text_element_style": {"bold": true}}}]}}
+```
+
+Code block language codes: 1=PlainText, 7=Python, 12=Java, 15=JavaScript, 22=Go, 33=SQL, 40=Bash
+
+### Example: Create doc with content
+
+```bash
+python scripts/doc_create.py --workspace-dir {working_dir} --title "Meeting Notes"
+# → get document_id from output, then set permissions via share.py
+
+python scripts/doc_edit.py --workspace-dir {working_dir} --doc-id DOC_ID --blocks-json '[
+  {"block_type": 3, "heading1": {"elements": [{"text_run": {"content": "Agenda"}}]}},
+  {"block_type": 9, "bullet": {"elements": [{"text_run": {"content": "Item 1"}}]}},
+  {"block_type": 9, "bullet": {"elements": [{"text_run": {"content": "Item 2"}}]}}
+]'
+```
+
+---
+
+## Module 2: Spreadsheets (Sheets)
+
+### Quick Reference
+
+| Task | Command |
+|------|---------|
+| Create spreadsheet | `python scripts/sheet_create.py --workspace-dir {working_dir} --title "Title" [--folder TOKEN]` |
+| Get info | `python scripts/sheet_read.py --workspace-dir {working_dir} --token TOKEN --info` |
+| List worksheets | `python scripts/sheet_read.py --workspace-dir {working_dir} --token TOKEN --list-sheets` |
+| Read range | `python scripts/sheet_read.py --workspace-dir {working_dir} --token TOKEN --range "SHEET_ID!A1:D10"` |
+| Write range | `python scripts/sheet_write.py --workspace-dir {working_dir} --token TOKEN --range "SHEET_ID!A1:B2" --values-json '[["a","b"],[1,2]]'` |
+| Append rows | `python scripts/sheet_write.py --workspace-dir {working_dir} --token TOKEN --range "SHEET_ID!A1" --append --values-json '[["c",3]]'` |
+| Add worksheet | `python scripts/sheet_write.py --workspace-dir {working_dir} --token TOKEN --add-sheet --sheet-title "Sheet2"` |
+
+### Range Format
+
+The `--range` parameter uses the format `<sheet_identifier>!<cell_range>`.
+
+**Recommended**: Use the worksheet's internal `sheet_id` (e.g. `e4731c!A1:B2`). Get it via `--list-sheets`.
+
+Sheet title (e.g. `Sheet1!A1:B2`) is also accepted — the script auto-resolves it to `sheet_id`. However, using `sheet_id` directly is more reliable and avoids an extra API call.
+
+**Workflow**: Always run `--list-sheets` first to get the `sheet_id`, then use it in subsequent read/write commands.
+
+### Value Types
+
+- String: `"text"`, Number: `123`, Boolean: `true`/`false`, Empty: `null`, Formula: `"=SUM(A1:A10)"`
+
+### Example: Create and populate
+
+```bash
+python scripts/sheet_create.py --workspace-dir {working_dir} --title "Q1 Report"
+# First, get the sheet_id
+python scripts/sheet_read.py --workspace-dir {working_dir} --token TOKEN --list-sheets
+# Use sheet_id (e.g. e4731c) from the output
+python scripts/sheet_write.py --workspace-dir {working_dir} --token TOKEN --range "e4731c!A1:C1" --values-json '[["Date","Revenue","Cost"]]'
+python scripts/sheet_write.py --workspace-dir {working_dir} --token TOKEN --range "e4731c!A2" --append --values-json '[["Jan",50000,30000],["Feb",55000,32000]]'
+```
+
+---
+
+## Module 3: Bitable (Multi-dimensional Table)
+
+### Quick Reference
+
+| Task | Command |
+|------|---------|
+| Create bitable | `python scripts/bitable_manage.py --workspace-dir {working_dir} create --name "Tracker" [--folder TOKEN]` |
+| List tables | `python scripts/bitable_manage.py --workspace-dir {working_dir} list-tables --app-token TOKEN` |
+| Add table | `python scripts/bitable_manage.py --workspace-dir {working_dir} add-table --app-token TOKEN --table-name "Tasks"` |
+| List fields | `python scripts/bitable_manage.py --workspace-dir {working_dir} list-fields --app-token TOKEN --table-id TID` |
+| Add field | `python scripts/bitable_manage.py --workspace-dir {working_dir} add-field --app-token TOKEN --table-id TID --field-name "Status" --field-type 3` |
+| List records | `python scripts/bitable_records.py --workspace-dir {working_dir} list --app-token TOKEN --table-id TID [--page-size 50]` |
+| Get record | `python scripts/bitable_records.py --workspace-dir {working_dir} get --app-token TOKEN --table-id TID --record-id RID` |
+| Create record | `python scripts/bitable_records.py --workspace-dir {working_dir} create --app-token TOKEN --table-id TID --fields-json '{...}'` |
+| Batch create | `python scripts/bitable_records.py --workspace-dir {working_dir} batch-create --app-token TOKEN --table-id TID --records-json '[...]'` |
+| Update record | `python scripts/bitable_records.py --workspace-dir {working_dir} update --app-token TOKEN --table-id TID --record-id RID --fields-json '{...}'` |
+| Delete record | `python scripts/bitable_records.py --workspace-dir {working_dir} delete --app-token TOKEN --table-id TID --record-id RID` |
+
+### Field Types
+
+| ID | Type | Value Format |
+|----|------|-------------|
+| 1 | Text | `"text"` |
+| 2 | Number | `123.45` (numeric, but may be returned as string in some cases — always convert with `float()` before arithmetic) |
+| 3 | SingleSelect | `"Option A"` |
+| 4 | MultiSelect | `["A", "B"]` |
+| 5 | DateTime | `1704067200000` (Unix ms) |
+| 7 | Checkbox | `true`/`false` |
+| 13 | Link | `{"text": "t", "link": "url"}` |
+
+**Important**: Use **field names** (e.g. `"文本"`, `"Status"`) as keys in `fields` when creating/updating records. Get field names via `list-fields`. Field IDs (e.g. `fldXXXXXX`) are also accepted but field names are recommended.
+
+---
+
+## Module 4: Wiki (Knowledge Base)
+
+> **Prerequisite**: The app must be added as a **wiki space collaborator** (editor or admin) before it can create/edit nodes. Ask the user to go to the wiki space settings → member settings → add the app as a member. Without this, all write operations will fail with permission denied.
+
+### Architecture: Structure vs Content
+
+Wiki module manages **structure** (nodes, hierarchy), not content. To write content into a wiki page:
+1. Create a node with `wiki.py create-node` → get `obj_token` from the response
+2. Use the corresponding content module to edit: `doc_edit.py --doc-id <obj_token>` for docx nodes, `sheet_write.py --token <obj_token>` for sheet nodes, etc.
+
+### Quick Reference
+
+| Task | Command |
+|------|---------|
+| List spaces | `python scripts/wiki.py --workspace-dir {working_dir} list-spaces` |
+| Create space | ⚠️ **Not supported via API** — requires `user_access_token` (OAuth). Ask the user to create the space manually in Feishu, then use `list-spaces` to get the `space_id`. |
+| List root nodes | `python scripts/wiki.py --workspace-dir {working_dir} list-nodes --space-id SID` |
+| List child nodes | `python scripts/wiki.py --workspace-dir {working_dir} list-nodes --space-id SID --parent-node-token TOKEN` |
+| Get node info | `python scripts/wiki.py --workspace-dir {working_dir} get-node --space-id SID --node-token TOKEN` |
+| Create doc node | `python scripts/wiki.py --workspace-dir {working_dir} create-node --space-id SID --obj-type docx --title "Page"` |
+| Create child node | `python scripts/wiki.py --workspace-dir {working_dir} create-node --space-id SID --obj-type docx --title "Sub" --parent-node-token TOKEN` |
+| Move node | `python scripts/wiki.py --workspace-dir {working_dir} move-node --space-id SID --node-token TOKEN --target-parent-token PARENT` |
+
+Supported `--obj-type`: `docx`, `sheet`, `bitable`, `mindnote`, `slides`
+
+**Key concept**: `get-node` returns `obj_token` — use it with the corresponding content module to read/edit (e.g. `doc_edit.py --doc-id <obj_token>` for docx, `sheet_write.py --token <obj_token>` for sheets).
+
+---
+
+## Sharing & Permissions
+
+Use `share.py` to manage permissions for any document type:
+
+```bash
+# Share with a user by open_id
+python scripts/share.py --workspace-dir {working_dir} --token TOKEN --type docx --member-type openid --member-id ou_xxx --perm view
+
+# Share by email
+python scripts/share.py --workspace-dir {working_dir} --token TOKEN --type sheet --member-type email --member-id user@example.com --perm edit
+
+# Set org-wide link sharing
+python scripts/share.py --workspace-dir {working_dir} --token TOKEN --type bitable --public --link-access tenant_editable
+
+# Transfer ownership to a user (app must be current owner)
+python scripts/share.py --workspace-dir {working_dir} --token TOKEN --type docx --transfer --member-type openid --member-id ou_xxx
+```
+
+`--type` values: `docx`, `sheet`, `bitable`, `wiki`, `file`, `folder`
+`--perm` values: `view`, `edit`, `full_access`
+`--link-access` values: `tenant_readable`, `tenant_editable`, `anyone_readable`, `anyone_editable`
+`--transfer`: Transfer document ownership to the specified member (requires `--member-type` and `--member-id`)
+---
+
+## Error Handling
+
+All scripts output JSON with `"success": true/false`. Common error codes:
+- `99991668`: No permission — check app permissions
+- `99991672`: Resource not found
+- `99991663`: Invalid access token — token expired or wrong type (some Wiki APIs require `user_access_token`)
+- `1254043`: Bitable permission error — add app as collaborator

--- a/skills/feishu_cloud_doc/scripts/bitable_manage.py
+++ b/skills/feishu_cloud_doc/scripts/bitable_manage.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Create and manage Feishu Bitable (multi-dimensional tables).
+
+Usage:
+    python scripts/bitable_manage.py create --name "Tracker"
+    python scripts/bitable_manage.py add-table --app-token TOKEN --table-name "Tasks"
+    python scripts/bitable_manage.py list-tables --app-token TOKEN
+    python scripts/bitable_manage.py list-fields --app-token TOKEN --table-id TABLE_ID
+    python scripts/bitable_manage.py add-field --app-token TOKEN --table-id TID --field-name "Status" --field-type 3
+
+Output: JSON with operation result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import httpx
+
+from feishu_auth import auth_headers, get_base_url, init_workspace
+
+
+def create_bitable(name: str, folder_token: str = "") -> dict:
+    """Create a new Bitable app."""
+    base = get_base_url()
+    url = f"{base}/open-apis/bitable/v1/apps"
+    body: dict = {"name": name}
+    if folder_token:
+        body["folder_token"] = folder_token
+
+    resp = httpx.post(url, headers=auth_headers(), json=body, timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    app = data.get("data", {}).get("app", {})
+    app_token = app.get("app_token", "")
+    app_url = app.get("url", "")
+    if not app_url and app_token:
+        domain = "larksuite.com" if "larksuite" in base else "feishu.cn"
+        app_url = f"https://{domain}/base/{app_token}"
+
+    return {
+        "success": True,
+        "app_token": app_token,
+        "name": app.get("name", name),
+        "url": app_url,
+    }
+
+
+def add_table(app_token: str, table_name: str) -> dict:
+    """Add a data table to a Bitable app."""
+    base = get_base_url()
+    url = f"{base}/open-apis/bitable/v1/apps/{app_token}/tables"
+    body = {"table": {"name": table_name}}
+
+    resp = httpx.post(url, headers=auth_headers(), json=body, timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    return {
+        "success": True,
+        "app_token": app_token,
+        "table_id": data.get("data", {}).get("table_id", ""),
+    }
+
+
+def list_tables(app_token: str) -> dict:
+    """List all tables in a Bitable app."""
+    base = get_base_url()
+    url = f"{base}/open-apis/bitable/v1/apps/{app_token}/tables"
+
+    resp = httpx.get(url, headers=auth_headers(), timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    items = data.get("data", {}).get("items", [])
+    return {
+        "success": True,
+        "app_token": app_token,
+        "table_count": len(items),
+        "tables": [
+            {
+                "table_id": t.get("table_id", ""),
+                "name": t.get("name", ""),
+                "revision": t.get("revision", 0),
+            }
+            for t in items
+        ],
+    }
+
+
+def list_fields(app_token: str, table_id: str) -> dict:
+    """List all fields in a table."""
+    base = get_base_url()
+    url = f"{base}/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/fields"
+
+    all_fields = []
+    page_token = ""
+    while True:
+        params: dict = {"page_size": 100}
+        if page_token:
+            params["page_token"] = page_token
+
+        resp = httpx.get(url, headers=auth_headers(), params=params, timeout=30)
+        data = resp.json()
+
+        if data.get("code") != 0:
+            return {
+                "success": False,
+                "error": data.get("msg", "unknown error"),
+                "code": data.get("code"),
+            }
+
+        items = data.get("data", {}).get("items", [])
+        all_fields.extend(items)
+
+        page_token = data.get("data", {}).get("page_token", "")
+        has_more = data.get("data", {}).get("has_more", False)
+        if not has_more or not page_token:
+            break
+
+    return {
+        "success": True,
+        "app_token": app_token,
+        "table_id": table_id,
+        "field_count": len(all_fields),
+        "fields": [
+            {
+                "field_id": f.get("field_id", ""),
+                "field_name": f.get("field_name", ""),
+                "type": f.get("type", 0),
+                "is_primary": f.get("is_primary", False),
+            }
+            for f in all_fields
+        ],
+    }
+
+
+def add_field(
+    app_token: str,
+    table_id: str,
+    field_name: str,
+    field_type: int,
+) -> dict:
+    """Add a field to a table."""
+    base = get_base_url()
+    url = f"{base}/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/fields"
+    body = {"field_name": field_name, "type": field_type}
+
+    resp = httpx.post(url, headers=auth_headers(), json=body, timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    field = data.get("data", {}).get("field", {})
+    return {
+        "success": True,
+        "app_token": app_token,
+        "table_id": table_id,
+        "field_id": field.get("field_id", ""),
+        "field_name": field.get("field_name", field_name),
+        "type": field.get("type", field_type),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Manage Feishu Bitable")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    create_p = sub.add_parser("create", help="Create a new Bitable")
+    create_p.add_argument("--name", required=True, help="Bitable name")
+    create_p.add_argument("--folder", default="", help="Folder token")
+
+    add_table_p = sub.add_parser("add-table", help="Add a table")
+    add_table_p.add_argument("--app-token", required=True)
+    add_table_p.add_argument("--table-name", required=True)
+
+    list_tables_p = sub.add_parser("list-tables", help="List tables")
+    list_tables_p.add_argument("--app-token", required=True)
+
+    list_fields_p = sub.add_parser("list-fields", help="List fields")
+    list_fields_p.add_argument("--app-token", required=True)
+    list_fields_p.add_argument("--table-id", required=True)
+
+    add_field_p = sub.add_parser("add-field", help="Add a field")
+    add_field_p.add_argument("--app-token", required=True)
+    add_field_p.add_argument("--table-id", required=True)
+    add_field_p.add_argument("--field-name", required=True)
+    add_field_p.add_argument("--field-type", type=int, required=True)
+
+    parser.add_argument("--workspace-dir", required=True, help="Workspace directory containing agent.json")
+    args = parser.parse_args()
+    init_workspace(args.workspace_dir)
+
+    if args.command == "create":
+        result = create_bitable(args.name, args.folder)
+    elif args.command == "add-table":
+        result = add_table(args.app_token, args.table_name)
+    elif args.command == "list-tables":
+        result = list_tables(args.app_token)
+    elif args.command == "list-fields":
+        result = list_fields(args.app_token, args.table_id)
+    elif args.command == "add-field":
+        result = add_field(args.app_token, args.table_id, args.field_name, args.field_type)
+    else:
+        result = {"success": False, "error": f"Unknown command: {args.command}"}
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    if not result.get("success"):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/feishu_cloud_doc/scripts/bitable_records.py
+++ b/skills/feishu_cloud_doc/scripts/bitable_records.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Read and write records in a Feishu Bitable table.
+
+Usage:
+    python scripts/records.py list --app-token TOKEN --table-id TABLE_ID [--page-size 20]
+    python scripts/records.py get --app-token TOKEN --table-id TABLE_ID --record-id REC_ID
+    python scripts/records.py create --app-token TOKEN --table-id TABLE_ID --fields-json '{"FieldName": "value"}'
+    python scripts/records.py batch-create --app-token TOKEN --table-id TABLE_ID --records-json '[{"fields": {...}}, ...]'
+    python scripts/records.py update --app-token TOKEN --table-id TABLE_ID --record-id REC_ID --fields-json '{"FieldName": "new"}'
+    python scripts/records.py delete --app-token TOKEN --table-id TABLE_ID --record-id REC_ID
+
+Output: JSON with operation result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import httpx
+
+from feishu_auth import auth_headers, get_base_url, init_workspace
+
+
+def list_records(
+    app_token: str,
+    table_id: str,
+    page_size: int = 20,
+    page_token: str = "",
+    filter_str: str = "",
+    sort_str: str = "",
+) -> dict:
+    """List records in a table with pagination."""
+    base = get_base_url()
+    url = f"{base}/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records"
+    params: dict = {"page_size": min(page_size, 500)}
+    if page_token:
+        params["page_token"] = page_token
+    if filter_str:
+        params["filter"] = filter_str
+    if sort_str:
+        params["sort"] = sort_str
+
+    resp = httpx.get(url, headers=auth_headers(), params=params, timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    result_data = data.get("data", {})
+    items = result_data.get("items", [])
+    return {
+        "success": True,
+        "app_token": app_token,
+        "table_id": table_id,
+        "total": result_data.get("total", len(items)),
+        "has_more": result_data.get("has_more", False),
+        "page_token": result_data.get("page_token", ""),
+        "record_count": len(items),
+        "records": [
+            {
+                "record_id": r.get("record_id", ""),
+                "fields": r.get("fields", {}),
+            }
+            for r in items
+        ],
+    }
+
+
+def get_record(app_token: str, table_id: str, record_id: str) -> dict:
+    """Get a single record by ID."""
+    base = get_base_url()
+    url = (
+        f"{base}/open-apis/bitable/v1/apps/{app_token}"
+        f"/tables/{table_id}/records/{record_id}"
+    )
+    resp = httpx.get(url, headers=auth_headers(), timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    record = data.get("data", {}).get("record", {})
+    return {
+        "success": True,
+        "record_id": record.get("record_id", record_id),
+        "fields": record.get("fields", {}),
+    }
+
+
+def create_record(app_token: str, table_id: str, fields: dict) -> dict:
+    """Create a single record."""
+    base = get_base_url()
+    url = f"{base}/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records"
+    body = {"fields": fields}
+
+    resp = httpx.post(url, headers=auth_headers(), json=body, timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    record = data.get("data", {}).get("record", {})
+    return {
+        "success": True,
+        "record_id": record.get("record_id", ""),
+        "fields": record.get("fields", {}),
+    }
+
+
+def batch_create_records(
+    app_token: str, table_id: str, records: list[dict]
+) -> dict:
+    """Batch create records (max 500 per call)."""
+    base = get_base_url()
+    url = (
+        f"{base}/open-apis/bitable/v1/apps/{app_token}"
+        f"/tables/{table_id}/records/batch_create"
+    )
+    body = {"records": records}
+
+    resp = httpx.post(url, headers=auth_headers(), json=body, timeout=60)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    created = data.get("data", {}).get("records", [])
+    return {
+        "success": True,
+        "created_count": len(created),
+        "record_ids": [r.get("record_id", "") for r in created],
+    }
+
+
+def update_record(
+    app_token: str, table_id: str, record_id: str, fields: dict
+) -> dict:
+    """Update a single record."""
+    base = get_base_url()
+    url = (
+        f"{base}/open-apis/bitable/v1/apps/{app_token}"
+        f"/tables/{table_id}/records/{record_id}"
+    )
+    body = {"fields": fields}
+
+    resp = httpx.put(url, headers=auth_headers(), json=body, timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    record = data.get("data", {}).get("record", {})
+    return {
+        "success": True,
+        "record_id": record.get("record_id", record_id),
+        "fields": record.get("fields", {}),
+    }
+
+
+def delete_record(app_token: str, table_id: str, record_id: str) -> dict:
+    """Delete a single record."""
+    base = get_base_url()
+    url = (
+        f"{base}/open-apis/bitable/v1/apps/{app_token}"
+        f"/tables/{table_id}/records/{record_id}"
+    )
+    resp = httpx.delete(url, headers=auth_headers(), timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    return {
+        "success": True,
+        "deleted": True,
+        "record_id": record_id,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Manage Bitable records")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    list_p = sub.add_parser("list", help="List records")
+    list_p.add_argument("--app-token", required=True)
+    list_p.add_argument("--table-id", required=True)
+    list_p.add_argument("--page-size", type=int, default=20)
+    list_p.add_argument("--page-token", default="")
+    list_p.add_argument("--filter", default="", dest="filter_str")
+    list_p.add_argument("--sort", default="", dest="sort_str")
+
+    get_p = sub.add_parser("get", help="Get a record")
+    get_p.add_argument("--app-token", required=True)
+    get_p.add_argument("--table-id", required=True)
+    get_p.add_argument("--record-id", required=True)
+
+    create_p = sub.add_parser("create", help="Create a record")
+    create_p.add_argument("--app-token", required=True)
+    create_p.add_argument("--table-id", required=True)
+    create_p.add_argument("--fields-json", required=True)
+
+    batch_p = sub.add_parser("batch-create", help="Batch create records")
+    batch_p.add_argument("--app-token", required=True)
+    batch_p.add_argument("--table-id", required=True)
+    batch_p.add_argument("--records-json", default="")
+    batch_p.add_argument("--records-file", default="")
+
+    update_p = sub.add_parser("update", help="Update a record")
+    update_p.add_argument("--app-token", required=True)
+    update_p.add_argument("--table-id", required=True)
+    update_p.add_argument("--record-id", required=True)
+    update_p.add_argument("--fields-json", required=True)
+
+    delete_p = sub.add_parser("delete", help="Delete a record")
+    delete_p.add_argument("--app-token", required=True)
+    delete_p.add_argument("--table-id", required=True)
+    delete_p.add_argument("--record-id", required=True)
+
+    parser.add_argument("--workspace-dir", required=True, help="Workspace directory containing agent.json")
+    args = parser.parse_args()
+    init_workspace(args.workspace_dir)
+
+    if args.command == "list":
+        result = list_records(
+            args.app_token,
+            args.table_id,
+            args.page_size,
+            args.page_token,
+            args.filter_str,
+            args.sort_str,
+        )
+    elif args.command == "get":
+        result = get_record(args.app_token, args.table_id, args.record_id)
+    elif args.command == "create":
+        fields = json.loads(args.fields_json)
+        result = create_record(args.app_token, args.table_id, fields)
+    elif args.command == "batch-create":
+        if args.records_file:
+            with open(args.records_file, encoding="utf-8") as fh:
+                records = json.load(fh)
+        elif args.records_json:
+            records = json.loads(args.records_json)
+        else:
+            print(json.dumps({"success": False, "error": "Provide --records-json or --records-file"}))
+            sys.exit(1)
+        result = batch_create_records(args.app_token, args.table_id, records)
+    elif args.command == "update":
+        fields = json.loads(args.fields_json)
+        result = update_record(args.app_token, args.table_id, args.record_id, fields)
+    elif args.command == "delete":
+        result = delete_record(args.app_token, args.table_id, args.record_id)
+    else:
+        result = {"success": False, "error": f"Unknown command: {args.command}"}
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    if not result.get("success"):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/feishu_cloud_doc/scripts/doc_create.py
+++ b/skills/feishu_cloud_doc/scripts/doc_create.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Create a new Feishu document.
+
+Usage:
+    python scripts/doc_create.py --title "Meeting Notes"
+    python scripts/doc_create.py --title "Notes" --folder FOLDER_TOKEN
+
+Output: JSON with document_id, url, etc.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import httpx
+
+from feishu_auth import auth_headers, get_base_url, init_workspace
+
+
+def create_document(title: str, folder_token: str = "") -> dict:
+    base = get_base_url()
+    url = f"{base}/open-apis/docx/v1/documents"
+    body: dict = {"title": title}
+    if folder_token:
+        body["folder_token"] = folder_token
+
+    resp = httpx.post(url, headers=auth_headers(), json=body, timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    doc = data.get("data", {}).get("document", {})
+    document_id = doc.get("document_id", "")
+    doc_url = doc.get("url", "")
+    if not doc_url and document_id:
+        domain = "larksuite.com" if "larksuite" in base else "feishu.cn"
+        doc_url = f"https://{domain}/docx/{document_id}"
+
+    return {
+        "success": True,
+        "document_id": document_id,
+        "title": doc.get("title", title),
+        "url": doc_url,
+        "revision_id": doc.get("revision_id", 1),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Create a Feishu document")
+    parser.add_argument("--title", required=True, help="Document title")
+    parser.add_argument("--folder", default="", help="Folder token (optional)")
+    parser.add_argument("--workspace-dir", required=True, help="Workspace directory containing agent.json")
+    args = parser.parse_args()
+    init_workspace(args.workspace_dir)
+
+    result = create_document(args.title, args.folder)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    if not result.get("success"):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/feishu_cloud_doc/scripts/doc_edit.py
+++ b/skills/feishu_cloud_doc/scripts/doc_edit.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Edit a Feishu document: add, delete, or search-and-delete blocks.
+
+Usage -- Add blocks:
+    python scripts/doc_edit.py --doc-id DOC_ID --blocks-json '[...]'
+    python scripts/doc_edit.py --doc-id DOC_ID --blocks-file blocks.json
+    python scripts/doc_edit.py --doc-id DOC_ID --parent-block-id BLOCK_ID --blocks-json '[...]'
+
+Usage -- Delete by block ID:
+    python scripts/doc_edit.py --doc-id DOC_ID --action delete --block-id BLOCK_ID
+
+Usage -- Delete by text content (searches all blocks, deletes those containing the text):
+    python scripts/doc_edit.py --doc-id DOC_ID --action delete-by-text --text "content to remove"
+
+Common block types:
+  - type 2 (text):     {"block_type": 2, "text": {"elements": [{"text_run": {"content": "Hello"}}]}}
+  - type 3 (heading1): {"block_type": 3, "heading1": {"elements": [{"text_run": {"content": "Title"}}]}}
+  - type 4 (heading2): {"block_type": 4, "heading2": {"elements": [{"text_run": {"content": "Sub"}}]}}
+  - type 9 (bullet):   {"block_type": 9, "bullet": {"elements": [{"text_run": {"content": "Item"}}]}}
+  - type 10 (ordered):  {"block_type": 10, "ordered": {"elements": [{"text_run": {"content": "Step 1"}}]}}
+  - type 12 (code):    {"block_type": 12, "code": {"elements": [{"text_run": {"content": "print(1)"}}], "style": {"language": 49}}}
+  - type 14 (divider): {"block_type": 14}
+
+Output: JSON with operation result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import httpx
+
+from feishu_auth import auth_headers, get_base_url, init_workspace
+
+
+def _fetch_all_blocks(document_id: str) -> list[dict] | None:
+    """Fetch all blocks of a document. Returns None on error."""
+    base = get_base_url()
+    url = f"{base}/open-apis/docx/v1/documents/{document_id}/blocks"
+    all_blocks: list[dict] = []
+    page_token = ""
+
+    while True:
+        params: dict = {"page_size": 500}
+        if page_token:
+            params["page_token"] = page_token
+
+        resp = httpx.get(url, headers=auth_headers(), params=params, timeout=30)
+        data = resp.json()
+        if data.get("code") != 0:
+            return None
+
+        all_blocks.extend(data.get("data", {}).get("items", []))
+        page_token = data.get("data", {}).get("page_token", "")
+        if not data.get("data", {}).get("has_more", False) or not page_token:
+            break
+
+    return all_blocks
+
+
+def _extract_block_text(block: dict) -> str:
+    """Extract plain text from a block's elements."""
+    block_type = block.get("block_type", 0)
+    type_key_map = {
+        2: "text", 3: "heading1", 4: "heading2", 5: "heading3",
+        6: "heading4", 7: "heading5", 8: "heading6",
+        9: "bullet", 10: "ordered", 12: "code",
+        15: "callout",
+    }
+    content_key = type_key_map.get(block_type, "")
+    if not content_key:
+        return ""
+
+    content_obj = block.get(content_key, {})
+    elements = content_obj.get("elements", [])
+    parts = []
+    for elem in elements:
+        text_run = elem.get("text_run", {})
+        if text_run:
+            parts.append(text_run.get("content", ""))
+    return "".join(parts)
+
+
+def _batch_delete_children(
+    document_id: str,
+    parent_block_id: str,
+    start_index: int,
+    end_index: int,
+) -> dict:
+    """Delete children of a parent block by index range.
+
+    Feishu API: DELETE /docx/v1/documents/{id}/blocks/{parent}/children/batch_delete
+    start_index: inclusive, >= 0
+    end_index: exclusive, >= 1
+    """
+    base = get_base_url()
+    url = (
+        f"{base}/open-apis/docx/v1/documents/{document_id}"
+        f"/blocks/{parent_block_id}/children/batch_delete"
+    )
+    body = {"start_index": start_index, "end_index": end_index}
+    resp = httpx.request("DELETE", url, headers=auth_headers(), json=body, timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    return {"success": True}
+
+
+def add_blocks(
+    document_id: str,
+    blocks: list[dict],
+    parent_block_id: str = "",
+    index: int = -1,
+) -> dict:
+    """Add child blocks to a document or a specific parent block.
+
+    If parent_block_id is empty, the document root block is used
+    (which equals the document_id itself).
+    """
+    parent = parent_block_id or document_id
+    base = get_base_url()
+    url = (
+        f"{base}/open-apis/docx/v1/documents/{document_id}"
+        f"/blocks/{parent}/children"
+    )
+
+    body: dict = {"children": blocks}
+    if index >= 0:
+        body["index"] = index
+
+    resp = httpx.post(url, headers=auth_headers(), json=body, timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    created = data.get("data", {}).get("children", [])
+    return {
+        "success": True,
+        "document_id": document_id,
+        "parent_block_id": parent,
+        "created_count": len(created),
+        "created_blocks": [
+            {"block_id": b.get("block_id", ""), "block_type": b.get("block_type", 0)}
+            for b in created
+        ],
+    }
+
+
+def delete_block(document_id: str, block_id: str) -> dict:
+    """Delete a specific block from a document by its block_id.
+
+    Finds the block's parent, determines the child index, then calls
+    batch_delete on the parent with the correct index range.
+    """
+    all_blocks = _fetch_all_blocks(document_id)
+    if all_blocks is None:
+        return {
+            "success": False,
+            "error": "Failed to fetch document blocks",
+        }
+
+    parent_block_id = ""
+    child_index = -1
+    for block in all_blocks:
+        children_ids = block.get("children", [])
+        if block_id in children_ids:
+            parent_block_id = block.get("block_id", "")
+            child_index = children_ids.index(block_id)
+            break
+
+    if not parent_block_id or child_index < 0:
+        return {
+            "success": False,
+            "error": f"Block {block_id} not found in any parent's children list",
+        }
+
+    result = _batch_delete_children(
+        document_id, parent_block_id, child_index, child_index + 1
+    )
+    if not result.get("success"):
+        return result
+
+    return {
+        "success": True,
+        "document_id": document_id,
+        "deleted_block_id": block_id,
+        "parent_block_id": parent_block_id,
+        "deleted_index": child_index,
+    }
+
+
+def delete_by_text(document_id: str, search_text: str, match_exact: bool = False) -> dict:
+    """Delete all blocks whose text content contains (or exactly matches) the search text.
+
+    Steps:
+    1. Fetch all blocks
+    2. Find blocks whose text contains search_text
+    3. Group by parent and delete via batch_delete (in reverse index order to avoid shifting)
+    """
+    all_blocks = _fetch_all_blocks(document_id)
+    if all_blocks is None:
+        return {
+            "success": False,
+            "error": "Failed to fetch document blocks",
+        }
+
+    matching_block_ids: list[str] = []
+    for block in all_blocks:
+        block_text = _extract_block_text(block)
+        if not block_text:
+            continue
+        if match_exact:
+            if block_text.strip() == search_text.strip():
+                matching_block_ids.append(block.get("block_id", ""))
+        else:
+            if search_text in block_text:
+                matching_block_ids.append(block.get("block_id", ""))
+
+    if not matching_block_ids:
+        return {
+            "success": False,
+            "error": f"No blocks found containing text: {search_text!r}",
+            "searched_block_count": len(all_blocks),
+        }
+
+    parent_to_indices: dict[str, list[int]] = {}
+    for block in all_blocks:
+        children_ids = block.get("children", [])
+        parent_id = block.get("block_id", "")
+        for idx, child_id in enumerate(children_ids):
+            if child_id in matching_block_ids:
+                parent_to_indices.setdefault(parent_id, []).append(idx)
+
+    deleted_blocks: list[dict] = []
+    errors: list[str] = []
+
+    for parent_id, indices in parent_to_indices.items():
+        sorted_indices = sorted(indices, reverse=True)
+        for idx in sorted_indices:
+            result = _batch_delete_children(document_id, parent_id, idx, idx + 1)
+            if result.get("success"):
+                deleted_blocks.append({"parent_id": parent_id, "index": idx})
+            else:
+                errors.append(
+                    f"Failed to delete index {idx} from parent {parent_id}: "
+                    f"{result.get('error', 'unknown')}"
+                )
+
+    return {
+        "success": len(deleted_blocks) > 0,
+        "document_id": document_id,
+        "search_text": search_text,
+        "matched_count": len(matching_block_ids),
+        "deleted_count": len(deleted_blocks),
+        "deleted_blocks": deleted_blocks,
+        "errors": errors if errors else None,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Edit a Feishu document")
+    parser.add_argument("--doc-id", required=True, help="Document ID")
+    parser.add_argument(
+        "--parent-block-id",
+        default="",
+        help="Parent block ID (default: document root)",
+    )
+    parser.add_argument(
+        "--blocks-json",
+        default="",
+        help="JSON array of block objects to add",
+    )
+    parser.add_argument(
+        "--blocks-file",
+        default="",
+        help="Path to JSON file containing block array",
+    )
+    parser.add_argument(
+        "--index",
+        type=int,
+        default=-1,
+        help="Insert position (-1 = append at end)",
+    )
+    parser.add_argument(
+        "--action",
+        choices=["add", "delete", "delete-by-text"],
+        default="add",
+        help="Action: add blocks, delete by block ID, or delete by text content",
+    )
+    parser.add_argument(
+        "--block-id",
+        default="",
+        help="Block ID to delete (for --action delete)",
+    )
+    parser.add_argument(
+        "--text",
+        default="",
+        help="Text to search and delete (for --action delete-by-text)",
+    )
+    parser.add_argument(
+        "--exact",
+        action="store_true",
+        help="Require exact text match instead of substring (for --action delete-by-text)",
+    )
+    parser.add_argument("--workspace-dir", required=True, help="Workspace directory containing agent.json")
+    args = parser.parse_args()
+    init_workspace(args.workspace_dir)
+
+    if args.action == "delete":
+        if not args.block_id:
+            print(json.dumps({"success": False, "error": "--block-id required for delete"}))
+            sys.exit(1)
+        result = delete_block(args.doc_id, args.block_id)
+    elif args.action == "delete-by-text":
+        if not args.text:
+            print(json.dumps({"success": False, "error": "--text required for delete-by-text"}))
+            sys.exit(1)
+        result = delete_by_text(args.doc_id, args.text, match_exact=args.exact)
+    else:
+        blocks_data: list[dict] = []
+        if args.blocks_file:
+            with open(args.blocks_file, encoding="utf-8") as fh:
+                blocks_data = json.load(fh)
+        elif args.blocks_json:
+            blocks_data = json.loads(args.blocks_json)
+        else:
+            print(json.dumps({"success": False, "error": "Provide --blocks-json or --blocks-file"}))
+            sys.exit(1)
+
+        if not isinstance(blocks_data, list):
+            blocks_data = [blocks_data]
+
+        result = add_blocks(
+            args.doc_id,
+            blocks_data,
+            parent_block_id=args.parent_block_id,
+            index=args.index,
+        )
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    if not result.get("success"):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/feishu_cloud_doc/scripts/doc_read.py
+++ b/skills/feishu_cloud_doc/scripts/doc_read.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Read a Feishu document's content.
+
+Usage:
+    python scripts/read_doc.py --doc-id DOC_ID [--format raw|blocks]
+
+Output: JSON with document content.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import httpx
+
+from feishu_auth import auth_headers, get_base_url, init_workspace
+
+
+def get_raw_content(document_id: str) -> dict:
+    """Get the plain-text content of a document."""
+    base = get_base_url()
+    url = f"{base}/open-apis/docx/v1/documents/{document_id}/raw_content"
+    resp = httpx.get(url, headers=auth_headers(), timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    return {
+        "success": True,
+        "document_id": document_id,
+        "content": data.get("data", {}).get("content", ""),
+    }
+
+
+def get_blocks(document_id: str) -> dict:
+    """Get the block tree of a document."""
+    base = get_base_url()
+    url = f"{base}/open-apis/docx/v1/documents/{document_id}/blocks"
+    all_blocks = []
+    page_token = ""
+
+    while True:
+        params: dict = {"page_size": 500}
+        if page_token:
+            params["page_token"] = page_token
+
+        resp = httpx.get(
+            url, headers=auth_headers(), params=params, timeout=30
+        )
+        data = resp.json()
+
+        if data.get("code") != 0:
+            return {
+                "success": False,
+                "error": data.get("msg", "unknown error"),
+                "code": data.get("code"),
+            }
+
+        items = data.get("data", {}).get("items", [])
+        all_blocks.extend(items)
+
+        page_token = data.get("data", {}).get("page_token", "")
+        has_more = data.get("data", {}).get("has_more", False)
+        if not has_more or not page_token:
+            break
+
+    return {
+        "success": True,
+        "document_id": document_id,
+        "block_count": len(all_blocks),
+        "blocks": all_blocks,
+    }
+
+
+def get_document_info(document_id: str) -> dict:
+    """Get document metadata (title, revision, etc.)."""
+    base = get_base_url()
+    url = f"{base}/open-apis/docx/v1/documents/{document_id}"
+    resp = httpx.get(url, headers=auth_headers(), timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    doc = data.get("data", {}).get("document", {})
+    return {
+        "success": True,
+        "document_id": doc.get("document_id", document_id),
+        "title": doc.get("title", ""),
+        "revision_id": doc.get("revision_id", 0),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Read a Feishu document")
+    parser.add_argument("--doc-id", required=True, help="Document ID")
+    parser.add_argument(
+        "--format",
+        choices=["raw", "blocks", "info"],
+        default="raw",
+        help="Output format: raw (plain text), blocks (block tree), info (metadata)",
+    )
+    parser.add_argument("--workspace-dir", required=True, help="Workspace directory containing agent.json")
+    args = parser.parse_args()
+    init_workspace(args.workspace_dir)
+
+    if args.format == "raw":
+        result = get_raw_content(args.doc_id)
+    elif args.format == "blocks":
+        result = get_blocks(args.doc_id)
+    else:
+        result = get_document_info(args.doc_id)
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    if not result.get("success"):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/feishu_cloud_doc/scripts/feishu_auth.py
+++ b/skills/feishu_cloud_doc/scripts/feishu_auth.py
@@ -1,0 +1,147 @@
+"""Feishu/Lark authentication helper.
+
+Provides tenant_access_token retrieval for scripts that call
+Feishu Open API.  Credentials are resolved in order:
+1. Environment variables: FEISHU_APP_ID / FEISHU_APP_SECRET
+2. Workspace agent.json → channels.feishu
+   (workspace dir passed via init_workspace() or --workspace-dir arg)
+
+Usage:
+    from feishu_auth import init_workspace, get_tenant_token, get_base_url
+    init_workspace("/path/to/workspace")   # call once before any API call
+    token = get_tenant_token()
+    base = get_base_url()
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Optional, Tuple
+
+import httpx
+
+_TOKEN_CACHE: dict[str, str] = {}
+_WORKSPACE_DIR: Optional[str] = None
+
+
+def init_workspace(workspace_dir: str) -> None:
+    """Set the workspace directory for credential resolution.
+
+    Call this once before any API call. The workspace directory contains
+    agent.json with Feishu credentials under channels.feishu.
+    """
+    global _WORKSPACE_DIR
+    _WORKSPACE_DIR = workspace_dir
+
+
+def _read_config_credentials() -> Tuple[str, str, str]:
+    """Read app_id, app_secret, domain from workspace agent.json."""
+    if not _WORKSPACE_DIR:
+        return "", "", "feishu"
+
+    agent_json = Path(_WORKSPACE_DIR).expanduser().resolve() / "agent.json"
+    if not agent_json.exists():
+        return "", "", "feishu"
+
+    try:
+        with open(agent_json, encoding="utf-8") as fh:
+            cfg = json.load(fh)
+        feishu_cfg = (cfg.get("channels") or {}).get("feishu") or {}
+        app_id = feishu_cfg.get("app_id") or ""
+        app_secret = feishu_cfg.get("app_secret") or ""
+        domain = feishu_cfg.get("domain") or "feishu"
+        if app_id and app_secret:
+            return app_id, app_secret, domain
+    except (json.JSONDecodeError, OSError):
+        pass
+
+    return "", "", "feishu"
+
+
+def get_credentials() -> Tuple[str, str, str]:
+    """Return (app_id, app_secret, domain).
+
+    Priority: environment variables > workspace agent.json.
+    """
+    app_id = os.environ.get("FEISHU_APP_ID", "")
+    app_secret = os.environ.get("FEISHU_APP_SECRET", "")
+    domain = os.environ.get("FEISHU_DOMAIN", "")
+
+    if not app_id or not app_secret:
+        cfg_id, cfg_secret, cfg_domain = _read_config_credentials()
+        app_id = app_id or cfg_id
+        app_secret = app_secret or cfg_secret
+        domain = domain or cfg_domain
+
+    domain = domain or "feishu"
+    return app_id, app_secret, domain
+
+
+def get_base_url(domain: str = "") -> str:
+    """Return the Open API base URL for the given domain."""
+    if not domain:
+        _, _, domain = get_credentials()
+    if domain == "lark":
+        return "https://open.larksuite.com"
+    return "https://open.feishu.cn"
+
+
+def get_tenant_token(force_refresh: bool = False) -> str:
+    """Obtain a tenant_access_token via the internal auth endpoint.
+
+    The token is cached in-process for the lifetime of the script.
+    """
+    app_id, app_secret, domain = get_credentials()
+    if not app_id or not app_secret:
+        print(
+            json.dumps(
+                {
+                    "success": False,
+                    "error": (
+                        "Feishu credentials not found. They should be in the "
+                        "workspace agent.json (channels.feishu.app_id/app_secret) "
+                        "or set via FEISHU_APP_ID/FEISHU_APP_SECRET env vars."
+                    ),
+                }
+            )
+        )
+        sys.exit(1)
+
+    cache_key = f"{app_id}:{domain}"
+    if not force_refresh and cache_key in _TOKEN_CACHE:
+        return _TOKEN_CACHE[cache_key]
+
+    base_url = get_base_url(domain)
+    url = f"{base_url}/open-apis/auth/v3/tenant_access_token/internal"
+    resp = httpx.post(
+        url,
+        json={"app_id": app_id, "app_secret": app_secret},
+        timeout=15,
+    )
+    data = resp.json()
+    if data.get("code") != 0:
+        print(
+            json.dumps(
+                {
+                    "success": False,
+                    "error": f"Failed to get tenant_access_token: {data.get('msg', 'unknown error')}",
+                    "code": data.get("code"),
+                }
+            )
+        )
+        sys.exit(1)
+
+    token = data["tenant_access_token"]
+    _TOKEN_CACHE[cache_key] = token
+    return token
+
+
+def auth_headers() -> dict[str, str]:
+    """Return standard Authorization + Content-Type headers."""
+    return {
+        "Authorization": f"Bearer {get_tenant_token()}",
+        "Content-Type": "application/json; charset=utf-8",
+    }

--- a/skills/feishu_cloud_doc/scripts/share.py
+++ b/skills/feishu_cloud_doc/scripts/share.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Manage permissions for a Feishu cloud document.
+
+Usage:
+    python scripts/share.py --workspace-dir DIR --token TOKEN --type docx --member-type openid --member-id ou_xxx --perm view
+    python scripts/share.py --workspace-dir DIR --token TOKEN --type docx --public --link-access tenant_readable
+    python scripts/share.py --workspace-dir DIR --token TOKEN --type docx --transfer --member-type openid --member-id ou_xxx
+
+Supported --type values: docx, sheet, bitable, wiki, file, folder
+Supported --perm values: view, edit, full_access
+Supported --link-access values: tenant_readable, tenant_editable, anyone_readable, anyone_editable
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import httpx
+
+from feishu_auth import auth_headers, get_base_url, init_workspace
+
+
+def add_member(
+    token: str,
+    doc_type: str,
+    member_type: str,
+    member_id: str,
+    perm: str = "view",
+) -> dict:
+    """Add a collaborator to a document."""
+    base = get_base_url()
+    url = (
+        f"{base}/open-apis/drive/v1/permissions/{token}/members"
+        f"?type={doc_type}&need_notification=false"
+    )
+    body = {
+        "member_type": member_type,
+        "member_id": member_id,
+        "perm": perm,
+    }
+    resp = httpx.post(url, headers=auth_headers(), json=body, timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    return {
+        "success": True,
+        "token": token,
+        "member_type": member_type,
+        "member_id": member_id,
+        "perm": perm,
+    }
+
+
+def set_public_access(
+    token: str,
+    doc_type: str,
+    link_share_entity: str = "tenant_readable",
+) -> dict:
+    """Set the link sharing permission for a document."""
+    base = get_base_url()
+    url = (
+        f"{base}/open-apis/drive/v1/permissions/{token}/public"
+        f"?type={doc_type}"
+    )
+    body = {
+        "external_access_entity": "open",
+        "security_entity": "anyone_can_view",
+        "comment_entity": "anyone_can_view",
+        "share_entity": "anyone",
+        "link_share_entity": link_share_entity,
+    }
+    resp = httpx.patch(url, headers=auth_headers(), json=body, timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    return {
+        "success": True,
+        "token": token,
+        "link_share_entity": link_share_entity,
+    }
+
+
+def transfer_owner(
+    token: str,
+    doc_type: str,
+    member_type: str,
+    member_id: str,
+) -> dict:
+    """Transfer document ownership to another user.
+
+    The caller (app) must be the current owner of the document.
+    After transfer, the new owner has full control and the app
+    becomes a regular collaborator.
+    """
+    base = get_base_url()
+    url = (
+        f"{base}/open-apis/drive/v1/permissions/{token}/members/transfer_owner"
+        f"?type={doc_type}&need_notification=true"
+    )
+    body = {
+        "member_type": member_type,
+        "member_id": member_id,
+    }
+    resp = httpx.post(url, headers=auth_headers(), json=body, timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    return {
+        "success": True,
+        "token": token,
+        "new_owner_type": member_type,
+        "new_owner_id": member_id,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Manage Feishu document permissions")
+    parser.add_argument("--token", required=True, help="Document/file token")
+    parser.add_argument(
+        "--type",
+        required=True,
+        choices=["docx", "sheet", "bitable", "wiki", "file", "folder"],
+        help="Document type",
+    )
+    parser.add_argument("--member-type", default="", help="Member type: openid, userid, email, chat_id, department_id")
+    parser.add_argument("--member-id", default="", help="Member ID")
+    parser.add_argument("--perm", default="view", choices=["view", "edit", "full_access"], help="Permission level")
+    parser.add_argument("--public", action="store_true", help="Set link sharing instead of adding member")
+    parser.add_argument(
+        "--link-access",
+        default="tenant_readable",
+        choices=["tenant_readable", "tenant_editable", "anyone_readable", "anyone_editable"],
+        help="Link sharing access level",
+    )
+    parser.add_argument("--transfer", action="store_true", help="Transfer ownership to the specified member")
+    parser.add_argument("--workspace-dir", required=True, help="Workspace directory containing agent.json")
+    args = parser.parse_args()
+    init_workspace(args.workspace_dir)
+
+    if args.transfer:
+        if not args.member_type or not args.member_id:
+            print(json.dumps({"success": False, "error": "--member-type and --member-id required for transfer"}))
+            sys.exit(1)
+        result = transfer_owner(args.token, args.type, args.member_type, args.member_id)
+    elif args.public:
+        result = set_public_access(args.token, args.type, args.link_access)
+    else:
+        if not args.member_type or not args.member_id:
+            print(json.dumps({"success": False, "error": "--member-type and --member-id required"}))
+            sys.exit(1)
+        result = add_member(args.token, args.type, args.member_type, args.member_id, args.perm)
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    if not result.get("success"):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/feishu_cloud_doc/scripts/sheet_create.py
+++ b/skills/feishu_cloud_doc/scripts/sheet_create.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Create a new Feishu spreadsheet.
+
+Usage:
+    python scripts/sheet_create.py --title "Sales Data"
+    python scripts/sheet_create.py --title "Data" --folder FOLDER_TOKEN
+
+Output: JSON with spreadsheet_token, url, etc.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import httpx
+
+from feishu_auth import auth_headers, get_base_url, init_workspace
+
+
+def create_spreadsheet(title: str, folder_token: str = "") -> dict:
+    base = get_base_url()
+    url = f"{base}/open-apis/sheets/v3/spreadsheets"
+    body: dict = {"title": title}
+    if folder_token:
+        body["folder_token"] = folder_token
+
+    resp = httpx.post(url, headers=auth_headers(), json=body, timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    sheet = data.get("data", {}).get("spreadsheet", {})
+    token = sheet.get("spreadsheet_token", "")
+    sheet_url = sheet.get("url", "")
+    if not sheet_url and token:
+        domain = "larksuite.com" if "larksuite" in base else "feishu.cn"
+        sheet_url = f"https://{domain}/sheets/{token}"
+
+    return {
+        "success": True,
+        "spreadsheet_token": token,
+        "title": sheet.get("title", title),
+        "url": sheet_url,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Create a Feishu spreadsheet")
+    parser.add_argument("--title", required=True, help="Spreadsheet title")
+    parser.add_argument("--folder", default="", help="Folder token (optional)")
+    parser.add_argument("--workspace-dir", required=True, help="Workspace directory containing agent.json")
+    args = parser.parse_args()
+    init_workspace(args.workspace_dir)
+
+    result = create_spreadsheet(args.title, args.folder)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    if not result.get("success"):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/feishu_cloud_doc/scripts/sheet_read.py
+++ b/skills/feishu_cloud_doc/scripts/sheet_read.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Read data from a Feishu spreadsheet.
+
+Usage:
+    python scripts/read_sheet.py --token TOKEN --range "Sheet1!A1:D10"
+    python scripts/read_sheet.py --token TOKEN --info
+    python scripts/read_sheet.py --token TOKEN --list-sheets
+
+Output: JSON with cell values or sheet metadata.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import httpx
+
+from feishu_auth import auth_headers, get_base_url, init_workspace
+
+
+def get_spreadsheet_info(token: str) -> dict:
+    """Get spreadsheet metadata."""
+    base = get_base_url()
+    url = f"{base}/open-apis/sheets/v3/spreadsheets/{token}"
+    resp = httpx.get(url, headers=auth_headers(), timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    sheet = data.get("data", {}).get("spreadsheet", {})
+    return {
+        "success": True,
+        "spreadsheet_token": sheet.get("spreadsheet_token", token),
+        "title": sheet.get("title", ""),
+    }
+
+
+def list_sheets(token: str) -> dict:
+    """List all worksheets in a spreadsheet."""
+    base = get_base_url()
+    url = f"{base}/open-apis/sheets/v3/spreadsheets/{token}/sheets/query"
+    resp = httpx.get(url, headers=auth_headers(), timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    sheets = data.get("data", {}).get("sheets", [])
+    return {
+        "success": True,
+        "spreadsheet_token": token,
+        "sheet_count": len(sheets),
+        "sheets": [
+            {
+                "sheet_id": s.get("sheet_id", ""),
+                "title": s.get("title", ""),
+                "index": s.get("index", 0),
+                "row_count": s.get("grid_properties", {}).get("row_count", 0),
+                "column_count": s.get("grid_properties", {}).get("column_count", 0),
+            }
+            for s in sheets
+        ],
+    }
+
+
+def _resolve_range(token: str, range_str: str) -> str:
+    """Resolve range by converting sheet title to sheet_id if needed.
+
+    Feishu Sheets API only accepts sheet_id (e.g. 'e4731c!A1:B2'),
+    not sheet title (e.g. 'Sheet1!A1:B2'). This function auto-converts
+    title to sheet_id by querying the worksheet list.
+    """
+    if "!" not in range_str:
+        return range_str
+    sheet_part, cell_part = range_str.split("!", 1)
+    result = list_sheets(token)
+    if not result.get("success"):
+        return range_str
+    for sheet in result.get("sheets", []):
+        if sheet.get("title") == sheet_part:
+            return f"{sheet['sheet_id']}!{cell_part}"
+    return range_str
+
+def read_range(token: str, range_str: str) -> dict:
+    """Read a range of cells from a spreadsheet.
+
+    Range format: "sheet_id!A1:D10" (recommended) or "SheetTitle!A1:D10"
+    (auto-resolved to sheet_id).
+    """
+    range_str = _resolve_range(token, range_str)
+    base = get_base_url()
+    url = f"{base}/open-apis/sheets/v2/spreadsheets/{token}/values/{range_str}"
+    params = {
+        "valueRenderOption": "ToString",
+        "dateTimeRenderOption": "FormattedString",
+    }
+    resp = httpx.get(url, headers=auth_headers(), params=params, timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    value_range = data.get("data", {}).get("valueRange", {})
+    return {
+        "success": True,
+        "spreadsheet_token": token,
+        "range": value_range.get("range", range_str),
+        "revision": data.get("data", {}).get("revision", 0),
+        "values": value_range.get("values", []),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Read a Feishu spreadsheet")
+    parser.add_argument("--token", required=True, help="Spreadsheet token")
+    parser.add_argument("--range", default="", help="Cell range (e.g. Sheet1!A1:D10)")
+    parser.add_argument("--info", action="store_true", help="Get spreadsheet metadata")
+    parser.add_argument("--list-sheets", action="store_true", help="List all worksheets")
+    parser.add_argument("--workspace-dir", required=True, help="Workspace directory containing agent.json")
+    args = parser.parse_args()
+    init_workspace(args.workspace_dir)
+
+    if args.info:
+        result = get_spreadsheet_info(args.token)
+    elif args.list_sheets:
+        result = list_sheets(args.token)
+    elif args.range:
+        result = read_range(args.token, args.range)
+    else:
+        print(json.dumps({"success": False, "error": "Specify --range, --info, or --list-sheets"}))
+        sys.exit(1)
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    if not result.get("success"):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/feishu_cloud_doc/scripts/sheet_write.py
+++ b/skills/feishu_cloud_doc/scripts/sheet_write.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Write data to a Feishu spreadsheet.
+
+Usage:
+    python scripts/write_sheet.py --token TOKEN --range "Sheet1!A1:B2" --values-json '[["Name","Score"],["Alice",95]]'
+    python scripts/write_sheet.py --token TOKEN --range "Sheet1!A1" --append --values-json '[["Bob",88]]'
+    python scripts/write_sheet.py --token TOKEN --add-sheet --sheet-title "New Sheet"
+
+Output: JSON with operation result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import httpx
+
+from feishu_auth import auth_headers, get_base_url, init_workspace
+
+
+def _list_sheets_for_resolve(token: str) -> list[dict]:
+    """Fetch worksheet list for range resolution."""
+    base = get_base_url()
+    url = f"{base}/open-apis/sheets/v3/spreadsheets/{token}/sheets/query"
+    resp = httpx.get(url, headers=auth_headers(), timeout=30)
+    data = resp.json()
+    if data.get("code") != 0:
+        return []
+    return [
+        {"sheet_id": s.get("sheet_id", ""), "title": s.get("title", "")}
+        for s in data.get("data", {}).get("sheets", [])
+    ]
+
+def _resolve_range(token: str, range_str: str) -> str:
+    """Resolve range by converting sheet title to sheet_id if needed.
+
+    Feishu Sheets API only accepts sheet_id (e.g. 'e4731c!A1:B2'),
+    not sheet title (e.g. 'Sheet1!A1:B2'). This function auto-converts
+    title to sheet_id by querying the worksheet list.
+    """
+    if "!" not in range_str:
+        return range_str
+    sheet_part, cell_part = range_str.split("!", 1)
+    for sheet in _list_sheets_for_resolve(token):
+        if sheet.get("title") == sheet_part:
+            return f"{sheet['sheet_id']}!{cell_part}"
+    return range_str
+
+def write_range(token: str, range_str: str, values: list[list]) -> dict:
+    """Write values to a specific range."""
+    range_str = _resolve_range(token, range_str)
+    base = get_base_url()
+    url = f"{base}/open-apis/sheets/v2/spreadsheets/{token}/values"
+    body = {
+        "valueRange": {
+            "range": range_str,
+            "values": values,
+        }
+    }
+    resp = httpx.put(url, headers=auth_headers(), json=body, timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    return {
+        "success": True,
+        "spreadsheet_token": token,
+        "range": range_str,
+        "updated_cells": data.get("data", {}).get("updatedCells", 0),
+        "updated_rows": data.get("data", {}).get("updatedRows", 0),
+        "updated_columns": data.get("data", {}).get("updatedColumns", 0),
+    }
+
+
+def append_data(token: str, range_str: str, values: list[list]) -> dict:
+    """Append values after the last row in a range."""
+    range_str = _resolve_range(token, range_str)
+    base = get_base_url()
+    url = f"{base}/open-apis/sheets/v2/spreadsheets/{token}/values_append"
+    params = {"insertDataOption": "INSERT_ROWS"}
+    body = {
+        "valueRange": {
+            "range": range_str,
+            "values": values,
+        }
+    }
+    resp = httpx.post(
+        url, headers=auth_headers(), params=params, json=body, timeout=30
+    )
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    updates = data.get("data", {}).get("updates", {})
+    return {
+        "success": True,
+        "spreadsheet_token": token,
+        "updated_range": updates.get("updatedRange", ""),
+        "updated_rows": updates.get("updatedRows", 0),
+        "updated_cells": updates.get("updatedCells", 0),
+    }
+
+
+def add_sheet(token: str, title: str, index: int = -1) -> dict:
+    """Add a new worksheet to the spreadsheet."""
+    base = get_base_url()
+    url = f"{base}/open-apis/sheets/v2/spreadsheets/{token}/sheets_batch_update"
+    add_req: dict = {"properties": {"title": title}}
+    if index >= 0:
+        add_req["properties"]["index"] = index
+    body = {"requests": [{"addSheet": add_req}]}
+
+    resp = httpx.post(url, headers=auth_headers(), json=body, timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    replies = data.get("data", {}).get("replies", [])
+    sheet_info = replies[0].get("addSheet", {}).get("properties", {}) if replies else {}
+    return {
+        "success": True,
+        "spreadsheet_token": token,
+        "sheet_id": sheet_info.get("sheetId", ""),
+        "title": sheet_info.get("title", title),
+        "index": sheet_info.get("index", 0),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Write to a Feishu spreadsheet")
+    parser.add_argument("--token", required=True, help="Spreadsheet token")
+    parser.add_argument("--range", default="", help="Cell range (e.g. Sheet1!A1:B2)")
+    parser.add_argument("--values-json", default="", help="JSON 2D array of values")
+    parser.add_argument("--values-file", default="", help="Path to JSON file with values")
+    parser.add_argument("--append", action="store_true", help="Append after last row instead of overwrite")
+    parser.add_argument("--add-sheet", action="store_true", help="Add a new worksheet")
+    parser.add_argument("--sheet-title", default="", help="Title for new worksheet")
+    parser.add_argument("--sheet-index", type=int, default=-1, help="Index for new worksheet")
+    parser.add_argument("--workspace-dir", required=True, help="Workspace directory containing agent.json")
+    args = parser.parse_args()
+    init_workspace(args.workspace_dir)
+
+    if args.add_sheet:
+        if not args.sheet_title:
+            print(json.dumps({"success": False, "error": "--sheet-title required with --add-sheet"}))
+            sys.exit(1)
+        result = add_sheet(args.token, args.sheet_title, args.sheet_index)
+    else:
+        if not args.range:
+            print(json.dumps({"success": False, "error": "--range required for read/write"}))
+            sys.exit(1)
+
+        values: list[list] = []
+        if args.values_file:
+            with open(args.values_file, encoding="utf-8") as fh:
+                values = json.load(fh)
+        elif args.values_json:
+            values = json.loads(args.values_json)
+        else:
+            print(json.dumps({"success": False, "error": "Provide --values-json or --values-file"}))
+            sys.exit(1)
+
+        if args.append:
+            result = append_data(args.token, args.range, values)
+        else:
+            result = write_range(args.token, args.range, values)
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    if not result.get("success"):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/feishu_cloud_doc/scripts/wiki.py
+++ b/skills/feishu_cloud_doc/scripts/wiki.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Manage Feishu Wiki (Knowledge Base) spaces and nodes.
+
+Usage:
+    python scripts/wiki.py list-spaces
+    python scripts/wiki.py create-space --name "Engineering Wiki" [--description "..."]
+    python scripts/wiki.py list-nodes --space-id SPACE_ID [--parent-node-token TOKEN]
+    python scripts/wiki.py get-node --space-id SPACE_ID --node-token TOKEN
+    python scripts/wiki.py create-node --space-id SPACE_ID --obj-type docx --title "Page Title" [--parent-node-token TOKEN]
+    python scripts/wiki.py move-node --space-id SPACE_ID --node-token TOKEN --target-parent-token PARENT
+
+Output: JSON with operation result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import httpx
+
+from feishu_auth import auth_headers, get_base_url, init_workspace
+
+
+def list_spaces(page_size: int = 50, page_token: str = "") -> dict:
+    """List all wiki spaces the app can access."""
+    base = get_base_url()
+    url = f"{base}/open-apis/wiki/v2/spaces"
+    params: dict = {"page_size": min(page_size, 50)}
+    if page_token:
+        params["page_token"] = page_token
+
+    resp = httpx.get(url, headers=auth_headers(), params=params, timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    result_data = data.get("data", {})
+    items = result_data.get("items", [])
+    return {
+        "success": True,
+        "has_more": result_data.get("has_more", False),
+        "page_token": result_data.get("page_token", ""),
+        "space_count": len(items),
+        "spaces": [
+            {
+                "space_id": s.get("space_id", ""),
+                "name": s.get("name", ""),
+                "description": s.get("description", ""),
+                "space_type": s.get("space_type", ""),
+                "visibility": s.get("visibility", ""),
+            }
+            for s in items
+        ],
+    }
+
+
+def create_space(name: str, description: str = "") -> dict:
+    """Create a new wiki space."""
+    base = get_base_url()
+    url = f"{base}/open-apis/wiki/v2/spaces"
+    body: dict = {"name": name}
+    if description:
+        body["description"] = description
+
+    resp = httpx.post(url, headers=auth_headers(), json=body, timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    space = data.get("data", {}).get("space", {})
+    return {
+        "success": True,
+        "space_id": space.get("space_id", ""),
+        "name": space.get("name", name),
+        "description": space.get("description", ""),
+    }
+
+
+def list_nodes(
+    space_id: str,
+    parent_node_token: str = "",
+    page_size: int = 50,
+    page_token: str = "",
+) -> dict:
+    """List child nodes of a wiki space or parent node."""
+    base = get_base_url()
+    url = f"{base}/open-apis/wiki/v2/spaces/{space_id}/nodes"
+    params: dict = {"page_size": min(page_size, 50)}
+    if parent_node_token:
+        params["parent_node_token"] = parent_node_token
+    if page_token:
+        params["page_token"] = page_token
+
+    resp = httpx.get(url, headers=auth_headers(), params=params, timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    result_data = data.get("data", {})
+    items = result_data.get("items", [])
+    return {
+        "success": True,
+        "space_id": space_id,
+        "has_more": result_data.get("has_more", False),
+        "page_token": result_data.get("page_token", ""),
+        "node_count": len(items),
+        "nodes": [
+            {
+                "node_token": n.get("node_token", ""),
+                "obj_token": n.get("obj_token", ""),
+                "obj_type": n.get("obj_type", ""),
+                "title": n.get("title", ""),
+                "has_child": n.get("has_child", False),
+                "parent_node_token": n.get("parent_node_token", ""),
+                "node_create_time": n.get("node_create_time", ""),
+            }
+            for n in items
+        ],
+    }
+
+
+def get_node(space_id: str, node_token: str) -> dict:
+    """Get information about a specific wiki node."""
+    base = get_base_url()
+    url = f"{base}/open-apis/wiki/v2/spaces/get_node"
+    params = {"token": node_token}
+
+    resp = httpx.get(url, headers=auth_headers(), params=params, timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    node = data.get("data", {}).get("node", {})
+    return {
+        "success": True,
+        "space_id": node.get("space_id", space_id),
+        "node_token": node.get("node_token", node_token),
+        "obj_token": node.get("obj_token", ""),
+        "obj_type": node.get("obj_type", ""),
+        "title": node.get("title", ""),
+        "has_child": node.get("has_child", False),
+        "parent_node_token": node.get("parent_node_token", ""),
+        "node_create_time": node.get("node_create_time", ""),
+        "obj_create_time": node.get("obj_create_time", ""),
+        "obj_edit_time": node.get("obj_edit_time", ""),
+        "creator": node.get("creator", ""),
+        "owner": node.get("owner", ""),
+    }
+
+
+def create_node(
+    space_id: str,
+    obj_type: str,
+    title: str,
+    parent_node_token: str = "",
+) -> dict:
+    """Create a new node in a wiki space.
+
+    obj_type: "docx" (document), "sheet" (spreadsheet), "bitable" (multi-table),
+              "mindnote" (mind map), "slides" (slides)
+    """
+    base = get_base_url()
+    url = f"{base}/open-apis/wiki/v2/spaces/{space_id}/nodes"
+    body: dict = {
+        "obj_type": obj_type,
+        "node_type": "origin",
+        "title": title,
+    }
+    if parent_node_token:
+        body["parent_node_token"] = parent_node_token
+
+    resp = httpx.post(url, headers=auth_headers(), json=body, timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    node = data.get("data", {}).get("node", {})
+    node_token = node.get("node_token", "")
+    obj_token = node.get("obj_token", "")
+
+    result: dict = {
+        "success": True,
+        "space_id": space_id,
+        "node_token": node_token,
+        "obj_token": obj_token,
+        "obj_type": node.get("obj_type", obj_type),
+        "title": node.get("title", title),
+    }
+
+    if obj_token:
+        domain = "larksuite.com" if "larksuite" in base else "feishu.cn"
+        if obj_type == "docx":
+            result["url"] = f"https://{domain}/docx/{obj_token}"
+        elif obj_type == "sheet":
+            result["url"] = f"https://{domain}/sheets/{obj_token}"
+        elif obj_type == "bitable":
+            result["url"] = f"https://{domain}/base/{obj_token}"
+
+    return result
+
+
+def move_node(
+    space_id: str,
+    node_token: str,
+    target_parent_token: str,
+) -> dict:
+    """Move a node to a new parent within the same space."""
+    base = get_base_url()
+    url = (
+        f"{base}/open-apis/wiki/v2/spaces/{space_id}"
+        f"/nodes/{node_token}/move"
+    )
+    body = {"target_parent_token": target_parent_token}
+
+    resp = httpx.post(url, headers=auth_headers(), json=body, timeout=30)
+    data = resp.json()
+
+    if data.get("code") != 0:
+        return {
+            "success": False,
+            "error": data.get("msg", "unknown error"),
+            "code": data.get("code"),
+        }
+
+    return {
+        "success": True,
+        "space_id": space_id,
+        "node_token": node_token,
+        "target_parent_token": target_parent_token,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Manage Feishu Wiki")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    list_spaces_p = sub.add_parser("list-spaces", help="List wiki spaces")
+    list_spaces_p.add_argument("--page-size", type=int, default=50)
+    list_spaces_p.add_argument("--page-token", default="")
+
+    create_space_p = sub.add_parser("create-space", help="Create a wiki space")
+    create_space_p.add_argument("--name", required=True)
+    create_space_p.add_argument("--description", default="")
+
+    list_nodes_p = sub.add_parser("list-nodes", help="List nodes in a space")
+    list_nodes_p.add_argument("--space-id", required=True)
+    list_nodes_p.add_argument("--parent-node-token", default="")
+    list_nodes_p.add_argument("--page-size", type=int, default=50)
+    list_nodes_p.add_argument("--page-token", default="")
+
+    get_node_p = sub.add_parser("get-node", help="Get node info")
+    get_node_p.add_argument("--space-id", required=True)
+    get_node_p.add_argument("--node-token", required=True)
+
+    create_node_p = sub.add_parser("create-node", help="Create a node")
+    create_node_p.add_argument("--space-id", required=True)
+    create_node_p.add_argument("--obj-type", required=True, choices=["docx", "sheet", "bitable", "mindnote", "slides"])
+    create_node_p.add_argument("--title", required=True)
+    create_node_p.add_argument("--parent-node-token", default="")
+
+    move_node_p = sub.add_parser("move-node", help="Move a node")
+    move_node_p.add_argument("--space-id", required=True)
+    move_node_p.add_argument("--node-token", required=True)
+    move_node_p.add_argument("--target-parent-token", required=True)
+
+    parser.add_argument("--workspace-dir", required=True, help="Workspace directory containing agent.json")
+    args = parser.parse_args()
+    init_workspace(args.workspace_dir)
+
+    if args.command == "list-spaces":
+        result = list_spaces(args.page_size, args.page_token)
+    elif args.command == "create-space":
+        result = create_space(args.name, args.description)
+    elif args.command == "list-nodes":
+        result = list_nodes(args.space_id, args.parent_node_token, args.page_size, args.page_token)
+    elif args.command == "get-node":
+        result = get_node(args.space_id, args.node_token)
+    elif args.command == "create-node":
+        result = create_node(args.space_id, args.obj_type, args.title, args.parent_node_token)
+    elif args.command == "move-node":
+        result = move_node(args.space_id, args.node_token, args.target_parent_token)
+    else:
+        result = {"success": False, "error": f"Unknown command: {args.command}"}
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    if not result.get("success"):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

Add a new builtin skill feishu_cloud_doc that enables the agent to operate on Feishu/Lark cloud documents via the Open API. Covers four major modules with 11 scripts.

### Features
Module 1: Documents (Docx)
- Create documents with optional folder placement (doc_create.py)
- Read documents in plain text, block tree, or metadata format (doc_read.py)
- Edit documents: add blocks (text, headings, bullets, code, etc.), insert at position, delete by block ID, delete by text content match (doc_edit.py)

Module 2: Spreadsheets (Sheets)
- Create spreadsheets (sheet_create.py)
- Read spreadsheet metadata, list worksheets, read cell ranges (sheet_read.py)
- Write cell ranges, append rows, add worksheets (sheet_write.py)

Module 3: Bitable (Multi-dimensional Table)
- Create bitables, manage tables and fields (bitable_manage.py)
- CRUD operations on records: list, get, create, batch create, update, delete (bitable_records.py)

Module 4: Wiki (Knowledge Base)
- List wiki spaces, list/get nodes, create nodes, move nodes (wiki.py)
- Note: create-space requires user_access_token (OAuth) and is not supported; users should create spaces manually

Sharing & Permissions
- Add collaborators by open_id, email, chat_id, etc. (share.py)
- Set link sharing permissions (org-readable, org-editable, anyone-readable, anyone-editable)
- Transfer document ownership from app to user via transfer_owner API

Authentication
- Centralized auth helper (feishu_auth.py) with tenant_access_token auto-retrieval and caching
- Credentials resolved from workspace agent.json via --workspace-dir argument (multi-workspace support)
- Fallback to FEISHU_APP_ID / FEISHU_APP_SECRET environment variables
- Supports both Feishu (China) and Lark (international) endpoints
